### PR TITLE
build: produce an arm64 tunnel.dll

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -31,6 +31,7 @@ if exist .deps\prepared goto :build
 	set CGO_LDFLAGS=%CGO_LDFLAGS% -Wl,--high-entropy-va
 	call :build_plat x64 x86_64 amd64 || goto :error
 	call :build_plat x86 i686 386 || goto :error
+	call :build_plat arm64 aarch64 arm64 || goto :error
 
 :success
 	echo [+] Success


### PR DESCRIPTION
`build.cmd` builds x64 and x86 only, so there is no arm64 `tunnel.dll` in the tree even though the bundled llvm-mingw toolchain ships `aarch64-w64-mingw32-gcc` and `wireguard-windows` has built all three architectures for years:

```
call :build_plat x86 i686 386
call :build_plat amd64 x86_64 amd64
call :build_plat arm64 aarch64 arm64
```

Windows-on-ARM is now mainstream enough that consumers hit this: while adding native ARM64 support to amnezia-client (amnezia-vpn/amnezia-client#2877) I had to drive the Go build directly from the Conan recipe to get an arm64 `tunnel.dll`. This restores parity with upstream so the shipped build script produces it.

Tested by building the arm64 `tunnel.dll` with the same toolchain and flags this script uses (Go with `CGO_ENABLED=1`, `GOARCH=arm64`, `CC=aarch64-w64-mingw32-gcc`) and running it on Windows 11 ARM64 (Snapdragon X Elite): the AmneziaWG tunnel connects and passes traffic.